### PR TITLE
feat: expose setBeacons method

### DIFF
--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -14,6 +14,7 @@ import 'package:drivekit_example/widgets/sliver_remove_all_drivekit_listeners.da
 import 'package:drivekit_example/widgets/sliver_remove_all_trip_listeners.dart';
 import 'package:drivekit_example/widgets/sliver_reset.dart';
 import 'package:drivekit_example/widgets/sliver_set_api_key.dart';
+import 'package:drivekit_example/widgets/sliver_set_beacons.dart';
 import 'package:drivekit_example/widgets/sliver_stop_timeout.dart';
 import 'package:drivekit_example/widgets/sliver_trip_lifecycle.dart';
 import 'package:drivekit_example/widgets/sliver_trip_metadata.dart';
@@ -106,6 +107,11 @@ class HomePage extends StatelessWidget {
             SliverPadding(
               padding: EdgeInsets.symmetric(horizontal: 16),
               sliver: SliverAddVehicle(),
+            ),
+            SliverGap(32),
+            SliverPadding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverSetBeacons(),
             ),
             SliverGap(32),
             SliverPadding(

--- a/example/lib/widgets/sliver_set_beacons.dart
+++ b/example/lib/widgets/sliver_set_beacons.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_drivekit_trip_analysis/flutter_drivekit_trip_analysis.dart';
+
+class SliverSetBeacons extends StatelessWidget {
+  const SliverSetBeacons({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: ElevatedButton(
+        onPressed: () {
+          DriveKitTripAnalysis.instance.setBeacons(
+            [
+              const BeaconData(
+                proximityUuid: '123e4567-e89b-12d3-a456-426614174000',
+                major: 1,
+                minor: 1,
+              ),
+              const BeaconData(
+                proximityUuid: '123e4567-e89b-12d3-a456-426614174001',
+                major: 1,
+                minor: 2,
+              ),
+            ],
+          );
+        },
+        child: const Text('Set beacons'),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -276,10 +276,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -409,10 +409,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timezone:
     dependency: transitive
     description:

--- a/packages/drivekit_core/flutter_drivekit_core/example/pubspec.lock
+++ b/packages/drivekit_core/flutter_drivekit_core/example/pubspec.lock
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_core/flutter_drivekit_core/pubspec.lock
+++ b/packages/drivekit_core/flutter_drivekit_core/pubspec.lock
@@ -124,10 +124,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -201,10 +201,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_core/flutter_drivekit_core_android/pubspec.lock
+++ b/packages/drivekit_core/flutter_drivekit_core_android/pubspec.lock
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_core/flutter_drivekit_core_ios/pubspec.lock
+++ b/packages/drivekit_core/flutter_drivekit_core_ios/pubspec.lock
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_core/flutter_drivekit_core_platform_interface/pubspec.lock
+++ b/packages/drivekit_core/flutter_drivekit_core_platform_interface/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_driver_data/flutter_drivekit_driver_data/example/pubspec.lock
+++ b/packages/drivekit_driver_data/flutter_drivekit_driver_data/example/pubspec.lock
@@ -138,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -207,10 +207,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_driver_data/flutter_drivekit_driver_data/pubspec.lock
+++ b/packages/drivekit_driver_data/flutter_drivekit_driver_data/pubspec.lock
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -208,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_driver_data/flutter_drivekit_driver_data_android/pubspec.lock
+++ b/packages/drivekit_driver_data/flutter_drivekit_driver_data_android/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_driver_data/flutter_drivekit_driver_data_ios/pubspec.lock
+++ b/packages/drivekit_driver_data/flutter_drivekit_driver_data_ios/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_driver_data/flutter_drivekit_driver_data_platform_interface/pubspec.lock
+++ b/packages/drivekit_driver_data/flutter_drivekit_driver_data_platform_interface/pubspec.lock
@@ -110,10 +110,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/example/pubspec.lock
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/example/pubspec.lock
@@ -138,10 +138,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -207,10 +207,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/lib/flutter_drivekit_trip_analysis.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/lib/flutter_drivekit_trip_analysis.dart
@@ -2,6 +2,7 @@ import 'package:flutter_drivekit_trip_analysis_platform_interface/flutter_drivek
 
 export 'package:flutter_drivekit_trip_analysis_platform_interface/flutter_drivekit_trip_analysis_platform_interface.dart'
     show
+        BeaconData,
         TripListener,
         TripResponseError,
         TripResponseInfo,
@@ -146,6 +147,11 @@ class DriveKitTripAnalysis {
   ///   driveWheels = 0
   Future<void> setVehicle(Vehicle vehicle) async {
     await _platform.setVehicle(vehicle);
+  }
+
+  /// Sets the list of beacons to be used for trip analysis
+  Future<void> setBeacons(List<BeaconData> beacons) async {
+    await _platform.setBeacons(beacons);
   }
 
   /// Add a listener to be notified of trip events

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/lib/flutter_drivekit_trip_analysis.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/lib/flutter_drivekit_trip_analysis.dart
@@ -150,6 +150,8 @@ class DriveKitTripAnalysis {
   }
 
   /// Sets the list of beacons to be used for trip analysis
+  /// You can use "-1" value for major and minor to match
+  /// all beacons with the same proximityUuid
   Future<void> setBeacons(List<BeaconData> beacons) async {
     await _platform.setBeacons(beacons);
   }

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/pubspec.lock
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis/pubspec.lock
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -208,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/DriveKitTripAnalysisPlugin.kt
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/DriveKitTripAnalysisPlugin.kt
@@ -96,6 +96,10 @@ class DriveKitTripAnalysisPlugin :
         DriveKitTripAnalysis.setVehicle(PigeonMapper.fromPigeonVehicle(vehicle))
     }
 
+    override fun setBeacons(beacons: List<PigeonBeaconData>) {
+        DriveKitTripAnalysis.setBeacons(beacons.map{ PigeonMapper.fromPigeonBeaconData(it)} )
+    }
+
     private fun configureTripListener() {
         DriveKitTripAnalysis.addTripListener(
             object : TripListener {

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/TripAnalysisApi.kt
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/TripAnalysisApi.kt
@@ -2409,6 +2409,7 @@ interface AndroidTripAnalysisApi {
   fun isMonitoringPotentialTripStart(): Boolean
   fun setMonitorPotentialTripStart(activate: Boolean)
   fun setVehicle(vehicle: PigeonVehicle)
+  fun setBeacons(beacon: List<PigeonBeaconData>)
   fun getTripMetadata(): Map<String, String>?
   fun updateTripMetadata(key: String, value: String?)
   fun setTripMetadata(metadata: Map<String, String>?)
@@ -2619,6 +2620,24 @@ interface AndroidTripAnalysisApi {
             val vehicleArg = args[0] as PigeonVehicle
             val wrapped: List<Any?> = try {
               api.setVehicle(vehicleArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setBeacons$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val beaconArg = args[0] as List<PigeonBeaconData>
+            val wrapped: List<Any?> = try {
+              api.setBeacons(beaconArg)
               listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/TripAnalysisApi.kt
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/TripAnalysisApi.kt
@@ -2409,7 +2409,7 @@ interface AndroidTripAnalysisApi {
   fun isMonitoringPotentialTripStart(): Boolean
   fun setMonitorPotentialTripStart(activate: Boolean)
   fun setVehicle(vehicle: PigeonVehicle)
-  fun setBeacons(beacon: List<PigeonBeaconData>)
+  fun setBeacons(beacons: List<PigeonBeaconData>)
   fun getTripMetadata(): Map<String, String>?
   fun updateTripMetadata(key: String, value: String?)
   fun setTripMetadata(metadata: Map<String, String>?)
@@ -2635,9 +2635,9 @@ interface AndroidTripAnalysisApi {
         if (api != null) {
           channel.setMessageHandler { message, reply ->
             val args = message as List<Any?>
-            val beaconArg = args[0] as List<PigeonBeaconData>
+            val beaconsArg = args[0] as List<PigeonBeaconData>
             val wrapped: List<Any?> = try {
-              api.setBeacons(beaconArg)
+              api.setBeacons(beaconsArg)
               listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/mapper/PigeonMapper.kt
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/android/src/main/kotlin/com/drivequant/drivekit/flutter/tripanalysis/mapper/PigeonMapper.kt
@@ -139,6 +139,10 @@ object PigeonMapper {
         driveWheels = pigeonVehicle.driveWheels.toInt()
     )
 
+    fun fromPigeonBeaconData(pigeonBeaconData: PigeonBeaconData): BeaconData = BeaconData(
+        pigeonBeaconData.proximityUuid, pigeonBeaconData.major.toInt(), pigeonBeaconData.minor.toInt()
+    )
+
     fun toPigeonStartMode(startMode: StartMode): PigeonStartMode = when (startMode) {
         StartMode.GPS -> PigeonStartMode.GPS
         StartMode.BEACON -> PigeonStartMode.BEACON

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/flutter_drivekit_trip_analysis_android.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/flutter_drivekit_trip_analysis_android.dart
@@ -77,6 +77,13 @@ class DriveKitTripAnalysisAndroid extends DriveKitTripAnalysisPlatform
       androidTripAnalysisApi.setVehicle(vehicle.toPigeonImplementation());
 
   @override
+  Future<void> setBeacons(List<BeaconData> beacon) =>
+      androidTripAnalysisApi.setBeacons(
+        beacon.map((b) => b.toPigeonImplementation(),
+      ).toList(),);
+
+
+  @override
   void addTripListener(TripListener listener) => _listeners.add(listener);
 
   @override

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/flutter_drivekit_trip_analysis_android.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/flutter_drivekit_trip_analysis_android.dart
@@ -77,9 +77,9 @@ class DriveKitTripAnalysisAndroid extends DriveKitTripAnalysisPlatform
       androidTripAnalysisApi.setVehicle(vehicle.toPigeonImplementation());
 
   @override
-  Future<void> setBeacons(List<BeaconData> beacon) =>
+  Future<void> setBeacons(List<BeaconData> beacons) =>
       androidTripAnalysisApi.setBeacons(
-        beacon.map((b) => b.toPigeonImplementation(),
+        beacons.map((b) => b.toPigeonImplementation(),
       ).toList(),);
 
 

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/src/adapter.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/src/adapter.dart
@@ -41,6 +41,18 @@ extension VehicleAdapter on Vehicle {
   }
 }
 
+/// Adapts the [BeaconData] class to the [PigeonBeaconData] class.
+extension BeaconDataAdapter on BeaconData {
+  /// Converts a [BeaconData] to a [PigeonBeaconData].
+  PigeonBeaconData toPigeonImplementation() {
+    return PigeonBeaconData(
+      proximityUuid: proximityUuid,
+      major: major,
+      minor: minor,
+    );
+  }
+}
+
 /// Adapts the [AdvancedEnergyEstimation] class to the corresponding Pigeon
 extension AdvancedEnergyEstimationAdapter on AdvancedEnergyEstimation {
   /// Converts a [AdvancedEnergyEstimation] to a corresponding Pigeon

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/src/trip_analysis_api.g.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/src/trip_analysis_api.g.dart
@@ -15,8 +15,7 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -30,7 +29,6 @@ List<Object?> wrapResponse(
 enum PigeonSynchronizationType {
   /// synchronize by calling the DriveQuant servers
   defaultSync,
-
   /// retrieve already synchronized items in the local database
   cache,
 }
@@ -398,8 +396,7 @@ class PigeonAdvancedEcoDriving {
   static PigeonAdvancedEcoDriving decode(Object result) {
     result as List<Object?>;
     return PigeonAdvancedEcoDriving(
-      ecoDrivingContext:
-          (result[0] as List<Object?>?)!.cast<PigeonEcoDrivingContext?>(),
+      ecoDrivingContext: (result[0] as List<Object?>?)!.cast<PigeonEcoDrivingContext?>(),
     );
   }
 }
@@ -420,8 +417,7 @@ class PigeonAdvancedFuelEstimation {
   static PigeonAdvancedFuelEstimation decode(Object result) {
     result as List<Object?>;
     return PigeonAdvancedFuelEstimation(
-      fuelEstimationContext:
-          (result[0] as List<Object?>?)!.cast<PigeonFuelEstimationContext?>(),
+      fuelEstimationContext: (result[0] as List<Object?>?)!.cast<PigeonFuelEstimationContext?>(),
     );
   }
 }
@@ -442,8 +438,7 @@ class PigeonAdvancedSafety {
   static PigeonAdvancedSafety decode(Object result) {
     result as List<Object?>;
     return PigeonAdvancedSafety(
-      safetyContext:
-          (result[0] as List<Object?>?)!.cast<PigeonSafetyContext?>(),
+      safetyContext: (result[0] as List<Object?>?)!.cast<PigeonSafetyContext?>(),
     );
   }
 }
@@ -1736,21 +1731,16 @@ class PigeonTrip {
       safetyEvents: (result[27] as List<Object?>?)?.cast<PigeonSafetyEvent?>(),
       speedingStatistics: result[28] as PigeonSpeedingStatistics?,
       energyEstimation: result[29] as PigeonEnergyEstimation?,
-      advancedEnergyEstimation: (result[30] as List<Object?>?)
-          ?.cast<PigeonAdvancedEnergyEstimation?>(),
-      tripAdvicesData:
-          (result[31] as List<Object?>?)?.cast<PigeonTripAdviceData?>(),
+      advancedEnergyEstimation: (result[30] as List<Object?>?)?.cast<PigeonAdvancedEnergyEstimation?>(),
+      tripAdvicesData: (result[31] as List<Object?>?)?.cast<PigeonTripAdviceData?>(),
       maneuverData: result[32] as PigeonManeuverData?,
       evaluationData: result[33] as PigeonEvaluationData?,
-      metadata:
-          (result[34] as Map<Object?, Object?>?)?.cast<String?, String?>(),
+      metadata: (result[34] as Map<Object?, Object?>?)?.cast<String?, String?>(),
       transportationMode: result[35]! as int,
-      declaredTransportationMode:
-          result[36] as PigeonDeclaredTransportationMode?,
+      declaredTransportationMode: result[36] as PigeonDeclaredTransportationMode?,
       unscored: result[37]! as bool,
       calls: (result[38] as List<Object?>?)?.cast<PigeonCall?>(),
-      speedLimitContexts:
-          (result[39] as List<Object?>?)?.cast<PigeonSpeedLimitContext?>(),
+      speedLimitContexts: (result[39] as List<Object?>?)?.cast<PigeonSpeedLimitContext?>(),
     );
   }
 }
@@ -2330,6 +2320,7 @@ class PigeonTripSharingLink {
   }
 }
 
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -2337,175 +2328,175 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is PigeonVehicle) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripPoint) {
+    } else     if (value is PigeonTripPoint) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonDKCrashInfo) {
+    } else     if (value is PigeonDKCrashInfo) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedEcoDriving) {
+    } else     if (value is PigeonAdvancedEcoDriving) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedFuelEstimation) {
+    } else     if (value is PigeonAdvancedFuelEstimation) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedSafety) {
+    } else     if (value is PigeonAdvancedSafety) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonBeaconData) {
+    } else     if (value is PigeonBeaconData) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonBrakeWear) {
+    } else     if (value is PigeonBrakeWear) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonCall) {
+    } else     if (value is PigeonCall) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedEnergyEstimation) {
+    } else     if (value is PigeonAdvancedEnergyEstimation) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEnergyEstimation) {
+    } else     if (value is PigeonEnergyEstimation) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEcoDriving) {
+    } else     if (value is PigeonEcoDriving) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonFuelEstimation) {
+    } else     if (value is PigeonFuelEstimation) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSafety) {
+    } else     if (value is PigeonSafety) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonPollutants) {
+    } else     if (value is PigeonPollutants) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTireWear) {
+    } else     if (value is PigeonTireWear) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonDriverDistraction) {
+    } else     if (value is PigeonDriverDistraction) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonLogbook) {
+    } else     if (value is PigeonLogbook) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonOccupantInfo) {
+    } else     if (value is PigeonOccupantInfo) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSafetyEvent) {
+    } else     if (value is PigeonSafetyEvent) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSpeedingStatistics) {
+    } else     if (value is PigeonSpeedingStatistics) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEcoDrivingContext) {
+    } else     if (value is PigeonEcoDrivingContext) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonFuelEstimationContext) {
+    } else     if (value is PigeonFuelEstimationContext) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSafetyContext) {
+    } else     if (value is PigeonSafetyContext) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSpeedLimitContext) {
+    } else     if (value is PigeonSpeedLimitContext) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripResponseStatus) {
+    } else     if (value is PigeonTripResponseStatus) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripResponseInfoItem) {
+    } else     if (value is PigeonTripResponseInfoItem) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTrip) {
+    } else     if (value is PigeonTrip) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripStatistics) {
+    } else     if (value is PigeonTripStatistics) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripAdviceData) {
+    } else     if (value is PigeonTripAdviceData) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripAdviceEvaluation) {
+    } else     if (value is PigeonTripAdviceEvaluation) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonManeuverData) {
+    } else     if (value is PigeonManeuverData) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEvaluationData) {
+    } else     if (value is PigeonEvaluationData) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonDeclaredTransportationMode) {
+    } else     if (value is PigeonDeclaredTransportationMode) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonCurrentTripInfo) {
+    } else     if (value is PigeonCurrentTripInfo) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonLastTripLocation) {
+    } else     if (value is PigeonLastTripLocation) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingStartedState) {
+    } else     if (value is PigeonTripRecordingStartedState) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingConfirmedState) {
+    } else     if (value is PigeonTripRecordingConfirmedState) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingCanceledState) {
+    } else     if (value is PigeonTripRecordingCanceledState) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingFinishedState) {
+    } else     if (value is PigeonTripRecordingFinishedState) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonCreateTripSharingLinkResponse) {
+    } else     if (value is PigeonCreateTripSharingLinkResponse) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonGetTripSharingLinkResponse) {
+    } else     if (value is PigeonGetTripSharingLinkResponse) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripSharingLink) {
+    } else     if (value is PigeonTripSharingLink) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSynchronizationType) {
+    } else     if (value is PigeonSynchronizationType) {
       buffer.putUint8(172);
       writeValue(buffer, value.index);
-    } else if (value is PigeonStartMode) {
+    } else     if (value is PigeonStartMode) {
       buffer.putUint8(173);
       writeValue(buffer, value.index);
-    } else if (value is PigeonState) {
+    } else     if (value is PigeonState) {
       buffer.putUint8(174);
       writeValue(buffer, value.index);
-    } else if (value is PigeonDKCrashFeedbackType) {
+    } else     if (value is PigeonDKCrashFeedbackType) {
       buffer.putUint8(175);
       writeValue(buffer, value.index);
-    } else if (value is PigeonDKCrashFeedbackSeverity) {
+    } else     if (value is PigeonDKCrashFeedbackSeverity) {
       buffer.putUint8(176);
       writeValue(buffer, value.index);
-    } else if (value is PigeonOccupantRole) {
+    } else     if (value is PigeonOccupantRole) {
       buffer.putUint8(177);
       writeValue(buffer, value.index);
-    } else if (value is PigeonCrashStatus) {
+    } else     if (value is PigeonCrashStatus) {
       buffer.putUint8(178);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripResponseStatusType) {
+    } else     if (value is PigeonTripResponseStatusType) {
       buffer.putUint8(179);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripResponseInfo) {
+    } else     if (value is PigeonTripResponseInfo) {
       buffer.putUint8(180);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripResponseError) {
+    } else     if (value is PigeonTripResponseError) {
       buffer.putUint8(181);
       writeValue(buffer, value.index);
-    } else if (value is PigeonAccuracyLevel) {
+    } else     if (value is PigeonAccuracyLevel) {
       buffer.putUint8(182);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripCancelationReason) {
+    } else     if (value is PigeonTripCancelationReason) {
       buffer.putUint8(183);
       writeValue(buffer, value.index);
-    } else if (value is PigeonCreateTripSharingLinkStatus) {
+    } else     if (value is PigeonCreateTripSharingLinkStatus) {
       buffer.putUint8(184);
       writeValue(buffer, value.index);
-    } else if (value is PigeonGetTripSharingLinkStatus) {
+    } else     if (value is PigeonGetTripSharingLinkStatus) {
       buffer.putUint8(185);
       writeValue(buffer, value.index);
-    } else if (value is PigeonRevokeTripSharingLinkStatus) {
+    } else     if (value is PigeonRevokeTripSharingLinkStatus) {
       buffer.putUint8(186);
       writeValue(buffer, value.index);
     } else {
@@ -2516,147 +2507,137 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         return PigeonVehicle.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return PigeonTripPoint.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return PigeonDKCrashInfo.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return PigeonAdvancedEcoDriving.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return PigeonAdvancedFuelEstimation.decode(readValue(buffer)!);
-      case 134:
+      case 134: 
         return PigeonAdvancedSafety.decode(readValue(buffer)!);
-      case 135:
+      case 135: 
         return PigeonBeaconData.decode(readValue(buffer)!);
-      case 136:
+      case 136: 
         return PigeonBrakeWear.decode(readValue(buffer)!);
-      case 137:
+      case 137: 
         return PigeonCall.decode(readValue(buffer)!);
-      case 138:
+      case 138: 
         return PigeonAdvancedEnergyEstimation.decode(readValue(buffer)!);
-      case 139:
+      case 139: 
         return PigeonEnergyEstimation.decode(readValue(buffer)!);
-      case 140:
+      case 140: 
         return PigeonEcoDriving.decode(readValue(buffer)!);
-      case 141:
+      case 141: 
         return PigeonFuelEstimation.decode(readValue(buffer)!);
-      case 142:
+      case 142: 
         return PigeonSafety.decode(readValue(buffer)!);
-      case 143:
+      case 143: 
         return PigeonPollutants.decode(readValue(buffer)!);
-      case 144:
+      case 144: 
         return PigeonTireWear.decode(readValue(buffer)!);
-      case 145:
+      case 145: 
         return PigeonDriverDistraction.decode(readValue(buffer)!);
-      case 146:
+      case 146: 
         return PigeonLogbook.decode(readValue(buffer)!);
-      case 147:
+      case 147: 
         return PigeonOccupantInfo.decode(readValue(buffer)!);
-      case 148:
+      case 148: 
         return PigeonSafetyEvent.decode(readValue(buffer)!);
-      case 149:
+      case 149: 
         return PigeonSpeedingStatistics.decode(readValue(buffer)!);
-      case 150:
+      case 150: 
         return PigeonEcoDrivingContext.decode(readValue(buffer)!);
-      case 151:
+      case 151: 
         return PigeonFuelEstimationContext.decode(readValue(buffer)!);
-      case 152:
+      case 152: 
         return PigeonSafetyContext.decode(readValue(buffer)!);
-      case 153:
+      case 153: 
         return PigeonSpeedLimitContext.decode(readValue(buffer)!);
-      case 154:
+      case 154: 
         return PigeonTripResponseStatus.decode(readValue(buffer)!);
-      case 155:
+      case 155: 
         return PigeonTripResponseInfoItem.decode(readValue(buffer)!);
-      case 156:
+      case 156: 
         return PigeonTrip.decode(readValue(buffer)!);
-      case 157:
+      case 157: 
         return PigeonTripStatistics.decode(readValue(buffer)!);
-      case 158:
+      case 158: 
         return PigeonTripAdviceData.decode(readValue(buffer)!);
-      case 159:
+      case 159: 
         return PigeonTripAdviceEvaluation.decode(readValue(buffer)!);
-      case 160:
+      case 160: 
         return PigeonManeuverData.decode(readValue(buffer)!);
-      case 161:
+      case 161: 
         return PigeonEvaluationData.decode(readValue(buffer)!);
-      case 162:
+      case 162: 
         return PigeonDeclaredTransportationMode.decode(readValue(buffer)!);
-      case 163:
+      case 163: 
         return PigeonCurrentTripInfo.decode(readValue(buffer)!);
-      case 164:
+      case 164: 
         return PigeonLastTripLocation.decode(readValue(buffer)!);
-      case 165:
+      case 165: 
         return PigeonTripRecordingStartedState.decode(readValue(buffer)!);
-      case 166:
+      case 166: 
         return PigeonTripRecordingConfirmedState.decode(readValue(buffer)!);
-      case 167:
+      case 167: 
         return PigeonTripRecordingCanceledState.decode(readValue(buffer)!);
-      case 168:
+      case 168: 
         return PigeonTripRecordingFinishedState.decode(readValue(buffer)!);
-      case 169:
+      case 169: 
         return PigeonCreateTripSharingLinkResponse.decode(readValue(buffer)!);
-      case 170:
+      case 170: 
         return PigeonGetTripSharingLinkResponse.decode(readValue(buffer)!);
-      case 171:
+      case 171: 
         return PigeonTripSharingLink.decode(readValue(buffer)!);
-      case 172:
+      case 172: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonSynchronizationType.values[value];
-      case 173:
+      case 173: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonStartMode.values[value];
-      case 174:
+      case 174: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonState.values[value];
-      case 175:
+      case 175: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonDKCrashFeedbackType.values[value];
-      case 176:
+      case 176: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonDKCrashFeedbackSeverity.values[value];
-      case 177:
+        return value == null ? null : PigeonDKCrashFeedbackSeverity.values[value];
+      case 177: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonOccupantRole.values[value];
-      case 178:
+      case 178: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonCrashStatus.values[value];
-      case 179:
+      case 179: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonTripResponseStatusType.values[value];
-      case 180:
+        return value == null ? null : PigeonTripResponseStatusType.values[value];
+      case 180: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonTripResponseInfo.values[value];
-      case 181:
+      case 181: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonTripResponseError.values[value];
-      case 182:
+      case 182: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonAccuracyLevel.values[value];
-      case 183:
+      case 183: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonTripCancelationReason.values[value];
-      case 184:
+      case 184: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonCreateTripSharingLinkStatus.values[value];
-      case 185:
+        return value == null ? null : PigeonCreateTripSharingLinkStatus.values[value];
+      case 185: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonGetTripSharingLinkStatus.values[value];
-      case 186:
+        return value == null ? null : PigeonGetTripSharingLinkStatus.values[value];
+      case 186: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonRevokeTripSharingLinkStatus.values[value];
+        return value == null ? null : PigeonRevokeTripSharingLinkStatus.values[value];
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -2667,11 +2648,9 @@ class AndroidTripAnalysisApi {
   /// Constructor for [AndroidTripAnalysisApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  AndroidTripAnalysisApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+  AndroidTripAnalysisApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : __pigeon_binaryMessenger = binaryMessenger,
-        __pigeon_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        __pigeon_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? __pigeon_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -2679,10 +2658,8 @@ class AndroidTripAnalysisApi {
   final String __pigeon_messageChannelSuffix;
 
   Future<bool> isAutoStartActivated() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isAutoStartActivated$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isAutoStartActivated$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2708,10 +2685,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> activateAutoStart(bool activate) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.activateAutoStart$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.activateAutoStart$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2732,10 +2707,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<bool> isCrashDetectionActivated() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isCrashDetectionActivated$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isCrashDetectionActivated$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2761,10 +2734,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> activateCrashDetection(bool activate) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.activateCrashDetection$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.activateCrashDetection$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2785,10 +2756,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> startTrip() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.startTrip$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.startTrip$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2809,10 +2778,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> stopTrip() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.stopTrip$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.stopTrip$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2833,10 +2800,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> cancelTrip() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.cancelTrip$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.cancelTrip$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2857,10 +2822,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<bool> isTripRunning() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isTripRunning$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isTripRunning$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2886,10 +2849,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> setStopTimeOut(int timeOut) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setStopTimeOut$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setStopTimeOut$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2910,10 +2871,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<bool> isMonitoringPotentialTripStart() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isMonitoringPotentialTripStart$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isMonitoringPotentialTripStart$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2939,10 +2898,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> setMonitorPotentialTripStart(bool activate) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setMonitorPotentialTripStart$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setMonitorPotentialTripStart$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2963,10 +2920,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> setVehicle(PigeonVehicle vehicle) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setVehicle$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setVehicle$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2986,11 +2941,31 @@ class AndroidTripAnalysisApi {
     }
   }
 
+  Future<void> setBeacons(List<PigeonBeaconData?> beacon) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setBeacons$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[beacon]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<Map<String?, String?>?> getTripMetadata() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3006,16 +2981,13 @@ class AndroidTripAnalysisApi {
         details: __pigeon_replyList[2],
       );
     } else {
-      return (__pigeon_replyList[0] as Map<Object?, Object?>?)
-          ?.cast<String?, String?>();
+      return (__pigeon_replyList[0] as Map<Object?, Object?>?)?.cast<String?, String?>();
     }
   }
 
   Future<void> updateTripMetadata(String key, String? value) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.updateTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.updateTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3036,10 +3008,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> setTripMetadata(Map<String?, String?>? metadata) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3060,10 +3030,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> deleteTripMetadata(String key) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.deleteTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.deleteTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3084,10 +3052,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<void> deleteAllTripMetadata() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.deleteAllTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.deleteAllTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3108,10 +3074,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<PigeonCurrentTripInfo?> getCurrentTripInfo() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getCurrentTripInfo$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getCurrentTripInfo$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3132,10 +3096,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<PigeonLastTripLocation?> getLastTripLocation() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getLastTripLocation$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getLastTripLocation$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3156,10 +3118,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<PigeonLastTripLocation?> getLastVehicleTripLocation() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getLastVehicleTripLocation$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getLastVehicleTripLocation$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3180,10 +3140,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<bool> isTripSharingAvailable() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isTripSharingAvailable$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.isTripSharingAvailable$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3208,18 +3166,15 @@ class AndroidTripAnalysisApi {
     }
   }
 
-  Future<PigeonCreateTripSharingLinkResponse> createTripSharingLink(
-      int durationInSeconds) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.createTripSharingLink$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+  Future<PigeonCreateTripSharingLinkResponse> createTripSharingLink(int durationInSeconds) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.createTripSharingLink$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[durationInSeconds]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[durationInSeconds]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -3238,19 +3193,15 @@ class AndroidTripAnalysisApi {
     }
   }
 
-  Future<PigeonGetTripSharingLinkResponse> getTripSharingLink(
-      {PigeonSynchronizationType synchronizationType =
-          PigeonSynchronizationType.defaultSync}) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getTripSharingLink$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+  Future<PigeonGetTripSharingLinkResponse> getTripSharingLink({PigeonSynchronizationType synchronizationType = PigeonSynchronizationType.defaultSync}) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.getTripSharingLink$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[synchronizationType]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[synchronizationType]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -3270,10 +3221,8 @@ class AndroidTripAnalysisApi {
   }
 
   Future<PigeonRevokeTripSharingLinkStatus> revokeTripSharingLink() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.revokeTripSharingLink$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.revokeTripSharingLink$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3326,33 +3275,22 @@ abstract class FlutterTripAnalysisApi {
 
   void crashDetected(PigeonDKCrashInfo crashInfo);
 
-  void crashFeedbackSent(
-      PigeonDKCrashInfo crashInfo,
-      PigeonDKCrashFeedbackType feedbackType,
-      PigeonDKCrashFeedbackSeverity severity);
+  void crashFeedbackSent(PigeonDKCrashInfo crashInfo, PigeonDKCrashFeedbackType feedbackType, PigeonDKCrashFeedbackSeverity severity);
 
-  static void setUp(
-    FlutterTripAnalysisApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(FlutterTripAnalysisApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingStartedState? arg_state =
-              (args[0] as PigeonTripRecordingStartedState?);
+          final PigeonTripRecordingStartedState? arg_state = (args[0] as PigeonTripRecordingStartedState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted was null, expected non-null PigeonTripRecordingStartedState.');
           try {
@@ -3360,28 +3298,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingConfirmedState? arg_state =
-              (args[0] as PigeonTripRecordingConfirmedState?);
+          final PigeonTripRecordingConfirmedState? arg_state = (args[0] as PigeonTripRecordingConfirmedState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed was null, expected non-null PigeonTripRecordingConfirmedState.');
           try {
@@ -3389,28 +3323,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingCanceledState? arg_state =
-              (args[0] as PigeonTripRecordingCanceledState?);
+          final PigeonTripRecordingCanceledState? arg_state = (args[0] as PigeonTripRecordingCanceledState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled was null, expected non-null PigeonTripRecordingCanceledState.');
           try {
@@ -3418,28 +3348,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingFinishedState? arg_state =
-              (args[0] as PigeonTripRecordingFinishedState?);
+          final PigeonTripRecordingFinishedState? arg_state = (args[0] as PigeonTripRecordingFinishedState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished was null, expected non-null PigeonTripRecordingFinishedState.');
           try {
@@ -3447,25 +3373,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonTripPoint? arg_tripPoint = (args[0] as PigeonTripPoint?);
           assert(arg_tripPoint != null,
@@ -3475,18 +3398,15 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripSavedForRepost$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripSavedForRepost$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
@@ -3497,28 +3417,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripResponseStatus? arg_response =
-              (args[0] as PigeonTripResponseStatus?);
+          final PigeonTripResponseStatus? arg_response = (args[0] as PigeonTripResponseStatus?);
           assert(arg_response != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished was null, expected non-null PigeonTripResponseStatus.');
           try {
@@ -3526,25 +3442,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonStartMode? arg_startMode = (args[0] as PigeonStartMode?);
           assert(arg_startMode != null,
@@ -3554,18 +3467,15 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconDetected$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconDetected$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
@@ -3576,25 +3486,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonBeaconData? arg_beacon = (args[0] as PigeonBeaconData?);
           assert(arg_beacon != null,
@@ -3604,25 +3511,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonState? arg_state = (args[0] as PigeonState?);
           assert(arg_state != null,
@@ -3632,28 +3536,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonDKCrashInfo? arg_crashInfo =
-              (args[0] as PigeonDKCrashInfo?);
+          final PigeonDKCrashInfo? arg_crashInfo = (args[0] as PigeonDKCrashInfo?);
           assert(arg_crashInfo != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected was null, expected non-null PigeonDKCrashInfo.');
           try {
@@ -3661,47 +3561,39 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonDKCrashInfo? arg_crashInfo =
-              (args[0] as PigeonDKCrashInfo?);
+          final PigeonDKCrashInfo? arg_crashInfo = (args[0] as PigeonDKCrashInfo?);
           assert(arg_crashInfo != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null, expected non-null PigeonDKCrashInfo.');
-          final PigeonDKCrashFeedbackType? arg_feedbackType =
-              (args[1] as PigeonDKCrashFeedbackType?);
+          final PigeonDKCrashFeedbackType? arg_feedbackType = (args[1] as PigeonDKCrashFeedbackType?);
           assert(arg_feedbackType != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null, expected non-null PigeonDKCrashFeedbackType.');
-          final PigeonDKCrashFeedbackSeverity? arg_severity =
-              (args[2] as PigeonDKCrashFeedbackSeverity?);
+          final PigeonDKCrashFeedbackSeverity? arg_severity = (args[2] as PigeonDKCrashFeedbackSeverity?);
           assert(arg_severity != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null, expected non-null PigeonDKCrashFeedbackSeverity.');
           try {
-            api.crashFeedbackSent(
-                arg_crashInfo!, arg_feedbackType!, arg_severity!);
+            api.crashFeedbackSent(arg_crashInfo!, arg_feedbackType!, arg_severity!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/src/trip_analysis_api.g.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/lib/src/trip_analysis_api.g.dart
@@ -2941,7 +2941,7 @@ class AndroidTripAnalysisApi {
     }
   }
 
-  Future<void> setBeacons(List<PigeonBeaconData?> beacon) async {
+  Future<void> setBeacons(List<PigeonBeaconData?> beacons) async {
     final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.AndroidTripAnalysisApi.setBeacons$__pigeon_messageChannelSuffix';
     final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
@@ -2949,7 +2949,7 @@ class AndroidTripAnalysisApi {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[beacon]) as List<Object?>?;
+        await __pigeon_channel.send(<Object?>[beacons]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/pigeon/messages.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/pigeon/messages.dart
@@ -28,6 +28,7 @@ abstract class AndroidTripAnalysisApi {
   bool isMonitoringPotentialTripStart();
   void setMonitorPotentialTripStart(bool activate);
   void setVehicle(PigeonVehicle vehicle);
+  void setBeacons(List<PigeonBeaconData> beacon);
   Map<String, String>? getTripMetadata();
   void updateTripMetadata(String key, String? value);
   void setTripMetadata(Map<String, String>? metadata);

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/pigeon/messages.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/pigeon/messages.dart
@@ -28,7 +28,7 @@ abstract class AndroidTripAnalysisApi {
   bool isMonitoringPotentialTripStart();
   void setMonitorPotentialTripStart(bool activate);
   void setVehicle(PigeonVehicle vehicle);
-  void setBeacons(List<PigeonBeaconData> beacon);
+  void setBeacons(List<PigeonBeaconData> beacons);
   Map<String, String>? getTripMetadata();
   void updateTripMetadata(String key, String? value);
   void setTripMetadata(Map<String, String>? metadata);

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/pubspec.lock
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_android/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/DriveKitTripAnalysisPlugin.swift
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/DriveKitTripAnalysisPlugin.swift
@@ -73,6 +73,12 @@ public class DriveKitTripAnalysisPlugin: NSObject, FlutterPlugin, IOSTripAnalysi
         )
     }
 
+    func setBeacons(beacons: [PigeonBeaconData]) throws {
+        DriveKitTripAnalysis.shared.setBeacons(
+            beacons: beacons.map { PigeonMapper.initTripBeacon(from: $0) }
+        )
+    }
+
     private func configureDriveTripDelegate() {
         DriveKitTripAnalysis.shared.addTripListener(self)
     }

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/IOSTripAnalysisApi.swift
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/IOSTripAnalysisApi.swift
@@ -2469,7 +2469,7 @@ protocol IOSTripAnalysisApi {
   func isMonitoringPotentialTripStart() throws -> Bool
   func setMonitorPotentialTripStart(activate: Bool) throws
   func setVehicle(vehicle: PigeonVehicle) throws
-  func setBeacons(beacon: [PigeonBeaconData]) throws
+  func setBeacons(beacons: [PigeonBeaconData]) throws
   func getTripMetadata() throws -> [String: String]?
   func updateTripMetadata(key: String, value: String?) throws
   func setTripMetadata(metadata: [String: String]?) throws
@@ -2660,9 +2660,9 @@ class IOSTripAnalysisApiSetup {
     if let api = api {
       setBeaconsChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
-        let beaconArg = args[0] as! [PigeonBeaconData]
+        let beaconsArg = args[0] as! [PigeonBeaconData]
         do {
-          try api.setBeacons(beacon: beaconArg)
+          try api.setBeacons(beacons: beaconsArg)
           reply(wrapResult(nil))
         } catch {
           reply(wrapError(error))

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/IOSTripAnalysisApi.swift
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/IOSTripAnalysisApi.swift
@@ -2469,6 +2469,7 @@ protocol IOSTripAnalysisApi {
   func isMonitoringPotentialTripStart() throws -> Bool
   func setMonitorPotentialTripStart(activate: Bool) throws
   func setVehicle(vehicle: PigeonVehicle) throws
+  func setBeacons(beacon: [PigeonBeaconData]) throws
   func getTripMetadata() throws -> [String: String]?
   func updateTripMetadata(key: String, value: String?) throws
   func setTripMetadata(metadata: [String: String]?) throws
@@ -2654,6 +2655,21 @@ class IOSTripAnalysisApiSetup {
       }
     } else {
       setVehicleChannel.setMessageHandler(nil)
+    }
+    let setBeaconsChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setBeacons\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      setBeaconsChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let beaconArg = args[0] as! [PigeonBeaconData]
+        do {
+          try api.setBeacons(beacon: beaconArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      setBeaconsChannel.setMessageHandler(nil)
     }
     let getTripMetadataChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getTripMetadata\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/PigeonMapper.swift
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/ios/flutter_drivekit_trip_analysis_ios/Sources/flutter_drivekit_trip_analysis_ios/PigeonMapper.swift
@@ -26,6 +26,14 @@ class PigeonMapper {
         tripVehicle.driveWheels = Int(pigeonVehicle.driveWheels)
         return tripVehicle
     }
+
+    static func initTripBeacon(from pigeonBeacon: PigeonBeaconData) -> BeaconData {
+        return BeaconData(
+            proximityUuid: pigeonBeacon.proximityUuid,
+            major: Int(pigeonBeacon.major),
+            minor: Int(pigeonBeacon.minor)
+        )
+    }
 }
 
 extension SynchronizationType {

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/flutter_drivekit_trip_analysis_ios.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/flutter_drivekit_trip_analysis_ios.dart
@@ -76,9 +76,9 @@ class DriveKitTripAnalysisIOS extends DriveKitTripAnalysisPlatform
       iosTripAnalysisApi.setVehicle(vehicle.toPigeonImplementation());
 
   @override
-  Future<void> setBeacons(List<BeaconData> beacon) =>
+  Future<void> setBeacons(List<BeaconData> beacons) =>
       iosTripAnalysisApi.setBeacons(
-        beacon.map((b) => b.toPigeonImplementation(),
+        beacons.map((b) => b.toPigeonImplementation(),
       ).toList(),);
 
   @override

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/flutter_drivekit_trip_analysis_ios.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/flutter_drivekit_trip_analysis_ios.dart
@@ -76,6 +76,12 @@ class DriveKitTripAnalysisIOS extends DriveKitTripAnalysisPlatform
       iosTripAnalysisApi.setVehicle(vehicle.toPigeonImplementation());
 
   @override
+  Future<void> setBeacons(List<BeaconData> beacon) =>
+      iosTripAnalysisApi.setBeacons(
+        beacon.map((b) => b.toPigeonImplementation(),
+      ).toList(),);
+
+  @override
   void addTripListener(TripListener listener) => _listeners.add(listener);
 
   @override

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/src/adapter.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/src/adapter.dart
@@ -28,6 +28,18 @@ extension VehicleAdapter on Vehicle {
   }
 }
 
+/// Adapts the [BeaconData] class to the [PigeonBeaconData] class.
+extension BeaconDataAdapter on BeaconData {
+  /// Converts a [BeaconData] to a [PigeonBeaconData].
+  PigeonBeaconData toPigeonImplementation() {
+    return PigeonBeaconData(
+      proximityUuid: proximityUuid,
+      major: major,
+      minor: minor,
+    );
+  }
+}
+
 /// Adapts the [AdvancedEnergyEstimation] class to the corresponding Pigeon
 extension AdvancedEnergyEstimationAdapter on AdvancedEnergyEstimation {
   /// Converts a [AdvancedEnergyEstimation] to a corresponding Pigeon

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/src/trip_analysis_api.g.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/src/trip_analysis_api.g.dart
@@ -15,8 +15,7 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -30,7 +29,6 @@ List<Object?> wrapResponse(
 enum PigeonSynchronizationType {
   /// synchronize by calling the DriveQuant servers
   defaultSync,
-
   /// retrieve already synchronized items in the local database
   cache,
 }
@@ -395,8 +393,7 @@ class PigeonAdvancedEcoDriving {
   static PigeonAdvancedEcoDriving decode(Object result) {
     result as List<Object?>;
     return PigeonAdvancedEcoDriving(
-      ecoDrivingContext:
-          (result[0] as List<Object?>?)!.cast<PigeonEcoDrivingContext?>(),
+      ecoDrivingContext: (result[0] as List<Object?>?)!.cast<PigeonEcoDrivingContext?>(),
     );
   }
 }
@@ -417,8 +414,7 @@ class PigeonAdvancedFuelEstimation {
   static PigeonAdvancedFuelEstimation decode(Object result) {
     result as List<Object?>;
     return PigeonAdvancedFuelEstimation(
-      fuelEstimationContext:
-          (result[0] as List<Object?>?)!.cast<PigeonFuelEstimationContext?>(),
+      fuelEstimationContext: (result[0] as List<Object?>?)!.cast<PigeonFuelEstimationContext?>(),
     );
   }
 }
@@ -439,8 +435,7 @@ class PigeonAdvancedSafety {
   static PigeonAdvancedSafety decode(Object result) {
     result as List<Object?>;
     return PigeonAdvancedSafety(
-      safetyContext:
-          (result[0] as List<Object?>?)!.cast<PigeonSafetyContext?>(),
+      safetyContext: (result[0] as List<Object?>?)!.cast<PigeonSafetyContext?>(),
     );
   }
 }
@@ -1759,21 +1754,16 @@ class PigeonTrip {
       safetyEvents: (result[27] as List<Object?>?)?.cast<PigeonSafetyEvent?>(),
       speedingStatistics: result[28] as PigeonSpeedingStatistics?,
       energyEstimation: result[29] as PigeonEnergyEstimation?,
-      advancedEnergyEstimation: (result[30] as List<Object?>?)
-          ?.cast<PigeonAdvancedEnergyEstimation?>(),
-      tripAdvicesData:
-          (result[31] as List<Object?>?)?.cast<PigeonTripAdviceData?>(),
+      advancedEnergyEstimation: (result[30] as List<Object?>?)?.cast<PigeonAdvancedEnergyEstimation?>(),
+      tripAdvicesData: (result[31] as List<Object?>?)?.cast<PigeonTripAdviceData?>(),
       maneuverData: result[32] as PigeonManeuverData?,
       evaluationData: result[33] as PigeonEvaluationData?,
-      metadata:
-          (result[34] as Map<Object?, Object?>?)?.cast<String?, String?>(),
+      metadata: (result[34] as Map<Object?, Object?>?)?.cast<String?, String?>(),
       transportationMode: result[35]! as int,
-      declaredTransportationMode:
-          result[36] as PigeonDeclaredTransportationMode?,
+      declaredTransportationMode: result[36] as PigeonDeclaredTransportationMode?,
       unscored: result[37]! as bool,
       calls: (result[38] as List<Object?>?)?.cast<PigeonCall?>(),
-      speedLimitContexts:
-          (result[39] as List<Object?>?)?.cast<PigeonSpeedLimitContext?>(),
+      speedLimitContexts: (result[39] as List<Object?>?)?.cast<PigeonSpeedLimitContext?>(),
     );
   }
 }
@@ -2353,6 +2343,7 @@ class PigeonTripSharingLink {
   }
 }
 
+
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -2360,178 +2351,178 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is PigeonVehicle) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripPoint) {
+    } else     if (value is PigeonTripPoint) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonDKCrashInfo) {
+    } else     if (value is PigeonDKCrashInfo) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedEcoDriving) {
+    } else     if (value is PigeonAdvancedEcoDriving) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedFuelEstimation) {
+    } else     if (value is PigeonAdvancedFuelEstimation) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedSafety) {
+    } else     if (value is PigeonAdvancedSafety) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonBeaconData) {
+    } else     if (value is PigeonBeaconData) {
       buffer.putUint8(135);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonBrakeWear) {
+    } else     if (value is PigeonBrakeWear) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonCall) {
+    } else     if (value is PigeonCall) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonAdvancedEnergyEstimation) {
+    } else     if (value is PigeonAdvancedEnergyEstimation) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEnergyEstimation) {
+    } else     if (value is PigeonEnergyEstimation) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEcoDriving) {
+    } else     if (value is PigeonEcoDriving) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonFuelEstimation) {
+    } else     if (value is PigeonFuelEstimation) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSafety) {
+    } else     if (value is PigeonSafety) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonPollutants) {
+    } else     if (value is PigeonPollutants) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTireWear) {
+    } else     if (value is PigeonTireWear) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonDriverDistraction) {
+    } else     if (value is PigeonDriverDistraction) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonLogbook) {
+    } else     if (value is PigeonLogbook) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonOccupantInfo) {
+    } else     if (value is PigeonOccupantInfo) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSafetyEvent) {
+    } else     if (value is PigeonSafetyEvent) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSpeedingStatistics) {
+    } else     if (value is PigeonSpeedingStatistics) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEcoDrivingContext) {
+    } else     if (value is PigeonEcoDrivingContext) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonFuelEstimationContext) {
+    } else     if (value is PigeonFuelEstimationContext) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSafetyContext) {
+    } else     if (value is PigeonSafetyContext) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSpeedLimitContext) {
+    } else     if (value is PigeonSpeedLimitContext) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonLocation) {
+    } else     if (value is PigeonLocation) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripResponseStatus) {
+    } else     if (value is PigeonTripResponseStatus) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripResponseInfoItem) {
+    } else     if (value is PigeonTripResponseInfoItem) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTrip) {
+    } else     if (value is PigeonTrip) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripStatistics) {
+    } else     if (value is PigeonTripStatistics) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripAdviceData) {
+    } else     if (value is PigeonTripAdviceData) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripAdviceEvaluation) {
+    } else     if (value is PigeonTripAdviceEvaluation) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonManeuverData) {
+    } else     if (value is PigeonManeuverData) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonEvaluationData) {
+    } else     if (value is PigeonEvaluationData) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonDeclaredTransportationMode) {
+    } else     if (value is PigeonDeclaredTransportationMode) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonCurrentTripInfo) {
+    } else     if (value is PigeonCurrentTripInfo) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonLastTripLocation) {
+    } else     if (value is PigeonLastTripLocation) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingStartedState) {
+    } else     if (value is PigeonTripRecordingStartedState) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingConfirmedState) {
+    } else     if (value is PigeonTripRecordingConfirmedState) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingCanceledState) {
+    } else     if (value is PigeonTripRecordingCanceledState) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripRecordingFinishedState) {
+    } else     if (value is PigeonTripRecordingFinishedState) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonCreateTripSharingLinkResponse) {
+    } else     if (value is PigeonCreateTripSharingLinkResponse) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonGetTripSharingLinkResponse) {
+    } else     if (value is PigeonGetTripSharingLinkResponse) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonTripSharingLink) {
+    } else     if (value is PigeonTripSharingLink) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is PigeonSynchronizationType) {
+    } else     if (value is PigeonSynchronizationType) {
       buffer.putUint8(173);
       writeValue(buffer, value.index);
-    } else if (value is PigeonStartMode) {
+    } else     if (value is PigeonStartMode) {
       buffer.putUint8(174);
       writeValue(buffer, value.index);
-    } else if (value is PigeonState) {
+    } else     if (value is PigeonState) {
       buffer.putUint8(175);
       writeValue(buffer, value.index);
-    } else if (value is PigeonDKCrashFeedbackType) {
+    } else     if (value is PigeonDKCrashFeedbackType) {
       buffer.putUint8(176);
       writeValue(buffer, value.index);
-    } else if (value is PigeonDKCrashFeedbackSeverity) {
+    } else     if (value is PigeonDKCrashFeedbackSeverity) {
       buffer.putUint8(177);
       writeValue(buffer, value.index);
-    } else if (value is PigeonOccupantRole) {
+    } else     if (value is PigeonOccupantRole) {
       buffer.putUint8(178);
       writeValue(buffer, value.index);
-    } else if (value is PigeonCrashStatus) {
+    } else     if (value is PigeonCrashStatus) {
       buffer.putUint8(179);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripResponseStatusType) {
+    } else     if (value is PigeonTripResponseStatusType) {
       buffer.putUint8(180);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripResponseInfo) {
+    } else     if (value is PigeonTripResponseInfo) {
       buffer.putUint8(181);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripResponseError) {
+    } else     if (value is PigeonTripResponseError) {
       buffer.putUint8(182);
       writeValue(buffer, value.index);
-    } else if (value is PigeonAccuracyLevel) {
+    } else     if (value is PigeonAccuracyLevel) {
       buffer.putUint8(183);
       writeValue(buffer, value.index);
-    } else if (value is PigeonTripCancelationReason) {
+    } else     if (value is PigeonTripCancelationReason) {
       buffer.putUint8(184);
       writeValue(buffer, value.index);
-    } else if (value is PigeonCreateTripSharingLinkStatus) {
+    } else     if (value is PigeonCreateTripSharingLinkStatus) {
       buffer.putUint8(185);
       writeValue(buffer, value.index);
-    } else if (value is PigeonGetTripSharingLinkStatus) {
+    } else     if (value is PigeonGetTripSharingLinkStatus) {
       buffer.putUint8(186);
       writeValue(buffer, value.index);
-    } else if (value is PigeonRevokeTripSharingLinkStatus) {
+    } else     if (value is PigeonRevokeTripSharingLinkStatus) {
       buffer.putUint8(187);
       writeValue(buffer, value.index);
     } else {
@@ -2542,149 +2533,139 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129:
+      case 129: 
         return PigeonVehicle.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return PigeonTripPoint.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return PigeonDKCrashInfo.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return PigeonAdvancedEcoDriving.decode(readValue(buffer)!);
-      case 133:
+      case 133: 
         return PigeonAdvancedFuelEstimation.decode(readValue(buffer)!);
-      case 134:
+      case 134: 
         return PigeonAdvancedSafety.decode(readValue(buffer)!);
-      case 135:
+      case 135: 
         return PigeonBeaconData.decode(readValue(buffer)!);
-      case 136:
+      case 136: 
         return PigeonBrakeWear.decode(readValue(buffer)!);
-      case 137:
+      case 137: 
         return PigeonCall.decode(readValue(buffer)!);
-      case 138:
+      case 138: 
         return PigeonAdvancedEnergyEstimation.decode(readValue(buffer)!);
-      case 139:
+      case 139: 
         return PigeonEnergyEstimation.decode(readValue(buffer)!);
-      case 140:
+      case 140: 
         return PigeonEcoDriving.decode(readValue(buffer)!);
-      case 141:
+      case 141: 
         return PigeonFuelEstimation.decode(readValue(buffer)!);
-      case 142:
+      case 142: 
         return PigeonSafety.decode(readValue(buffer)!);
-      case 143:
+      case 143: 
         return PigeonPollutants.decode(readValue(buffer)!);
-      case 144:
+      case 144: 
         return PigeonTireWear.decode(readValue(buffer)!);
-      case 145:
+      case 145: 
         return PigeonDriverDistraction.decode(readValue(buffer)!);
-      case 146:
+      case 146: 
         return PigeonLogbook.decode(readValue(buffer)!);
-      case 147:
+      case 147: 
         return PigeonOccupantInfo.decode(readValue(buffer)!);
-      case 148:
+      case 148: 
         return PigeonSafetyEvent.decode(readValue(buffer)!);
-      case 149:
+      case 149: 
         return PigeonSpeedingStatistics.decode(readValue(buffer)!);
-      case 150:
+      case 150: 
         return PigeonEcoDrivingContext.decode(readValue(buffer)!);
-      case 151:
+      case 151: 
         return PigeonFuelEstimationContext.decode(readValue(buffer)!);
-      case 152:
+      case 152: 
         return PigeonSafetyContext.decode(readValue(buffer)!);
-      case 153:
+      case 153: 
         return PigeonSpeedLimitContext.decode(readValue(buffer)!);
-      case 154:
+      case 154: 
         return PigeonLocation.decode(readValue(buffer)!);
-      case 155:
+      case 155: 
         return PigeonTripResponseStatus.decode(readValue(buffer)!);
-      case 156:
+      case 156: 
         return PigeonTripResponseInfoItem.decode(readValue(buffer)!);
-      case 157:
+      case 157: 
         return PigeonTrip.decode(readValue(buffer)!);
-      case 158:
+      case 158: 
         return PigeonTripStatistics.decode(readValue(buffer)!);
-      case 159:
+      case 159: 
         return PigeonTripAdviceData.decode(readValue(buffer)!);
-      case 160:
+      case 160: 
         return PigeonTripAdviceEvaluation.decode(readValue(buffer)!);
-      case 161:
+      case 161: 
         return PigeonManeuverData.decode(readValue(buffer)!);
-      case 162:
+      case 162: 
         return PigeonEvaluationData.decode(readValue(buffer)!);
-      case 163:
+      case 163: 
         return PigeonDeclaredTransportationMode.decode(readValue(buffer)!);
-      case 164:
+      case 164: 
         return PigeonCurrentTripInfo.decode(readValue(buffer)!);
-      case 165:
+      case 165: 
         return PigeonLastTripLocation.decode(readValue(buffer)!);
-      case 166:
+      case 166: 
         return PigeonTripRecordingStartedState.decode(readValue(buffer)!);
-      case 167:
+      case 167: 
         return PigeonTripRecordingConfirmedState.decode(readValue(buffer)!);
-      case 168:
+      case 168: 
         return PigeonTripRecordingCanceledState.decode(readValue(buffer)!);
-      case 169:
+      case 169: 
         return PigeonTripRecordingFinishedState.decode(readValue(buffer)!);
-      case 170:
+      case 170: 
         return PigeonCreateTripSharingLinkResponse.decode(readValue(buffer)!);
-      case 171:
+      case 171: 
         return PigeonGetTripSharingLinkResponse.decode(readValue(buffer)!);
-      case 172:
+      case 172: 
         return PigeonTripSharingLink.decode(readValue(buffer)!);
-      case 173:
+      case 173: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonSynchronizationType.values[value];
-      case 174:
+      case 174: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonStartMode.values[value];
-      case 175:
+      case 175: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonState.values[value];
-      case 176:
+      case 176: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonDKCrashFeedbackType.values[value];
-      case 177:
+      case 177: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonDKCrashFeedbackSeverity.values[value];
-      case 178:
+        return value == null ? null : PigeonDKCrashFeedbackSeverity.values[value];
+      case 178: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonOccupantRole.values[value];
-      case 179:
+      case 179: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonCrashStatus.values[value];
-      case 180:
+      case 180: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonTripResponseStatusType.values[value];
-      case 181:
+        return value == null ? null : PigeonTripResponseStatusType.values[value];
+      case 181: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonTripResponseInfo.values[value];
-      case 182:
+      case 182: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonTripResponseError.values[value];
-      case 183:
+      case 183: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonAccuracyLevel.values[value];
-      case 184:
+      case 184: 
         final int? value = readValue(buffer) as int?;
         return value == null ? null : PigeonTripCancelationReason.values[value];
-      case 185:
+      case 185: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonCreateTripSharingLinkStatus.values[value];
-      case 186:
+        return value == null ? null : PigeonCreateTripSharingLinkStatus.values[value];
+      case 186: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonGetTripSharingLinkStatus.values[value];
-      case 187:
+        return value == null ? null : PigeonGetTripSharingLinkStatus.values[value];
+      case 187: 
         final int? value = readValue(buffer) as int?;
-        return value == null
-            ? null
-            : PigeonRevokeTripSharingLinkStatus.values[value];
+        return value == null ? null : PigeonRevokeTripSharingLinkStatus.values[value];
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -2695,11 +2676,9 @@ class IOSTripAnalysisApi {
   /// Constructor for [IOSTripAnalysisApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  IOSTripAnalysisApi(
-      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+  IOSTripAnalysisApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : __pigeon_binaryMessenger = binaryMessenger,
-        __pigeon_messageChannelSuffix =
-            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        __pigeon_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? __pigeon_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -2707,10 +2686,8 @@ class IOSTripAnalysisApi {
   final String __pigeon_messageChannelSuffix;
 
   Future<bool> isAutoStartActivated() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isAutoStartActivated$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isAutoStartActivated$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2736,10 +2713,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> activateAutoStart(bool activate) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.activateAutoStart$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.activateAutoStart$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2760,10 +2735,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<bool> isCrashDetectionActivated() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isCrashDetectionActivated$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isCrashDetectionActivated$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2789,10 +2762,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> activateCrashDetection(bool activate) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.activateCrashDetection$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.activateCrashDetection$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2813,10 +2784,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> startTrip() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.startTrip$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.startTrip$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2837,10 +2806,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> stopTrip() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.stopTrip$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.stopTrip$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2861,10 +2828,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> cancelTrip() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.cancelTrip$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.cancelTrip$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2885,10 +2850,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<bool> isTripRunning() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isTripRunning$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isTripRunning$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2914,10 +2877,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> setStopTimeOut(int timeOut) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setStopTimeOut$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setStopTimeOut$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2938,10 +2899,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<bool> isMonitoringPotentialTripStart() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isMonitoringPotentialTripStart$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isMonitoringPotentialTripStart$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2967,10 +2926,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> setMonitorPotentialTripStart(bool activate) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setMonitorPotentialTripStart$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setMonitorPotentialTripStart$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -2991,10 +2948,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> setVehicle(PigeonVehicle vehicle) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setVehicle$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setVehicle$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3014,11 +2969,31 @@ class IOSTripAnalysisApi {
     }
   }
 
+  Future<void> setBeacons(List<PigeonBeaconData?> beacon) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setBeacons$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[beacon]) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<Map<String?, String?>?> getTripMetadata() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3034,16 +3009,13 @@ class IOSTripAnalysisApi {
         details: __pigeon_replyList[2],
       );
     } else {
-      return (__pigeon_replyList[0] as Map<Object?, Object?>?)
-          ?.cast<String?, String?>();
+      return (__pigeon_replyList[0] as Map<Object?, Object?>?)?.cast<String?, String?>();
     }
   }
 
   Future<void> updateTripMetadata(String key, String? value) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.updateTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.updateTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3064,10 +3036,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> setTripMetadata(Map<String?, String?>? metadata) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3088,10 +3058,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> deleteTripMetadata(String key) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.deleteTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.deleteTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3112,10 +3080,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<void> deleteAllTripMetadata() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.deleteAllTripMetadata$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.deleteAllTripMetadata$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3136,10 +3102,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<PigeonCurrentTripInfo?> getCurrentTripInfo() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getCurrentTripInfo$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getCurrentTripInfo$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3160,10 +3124,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<PigeonLastTripLocation?> getLastTripLocation() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getLastTripLocation$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getLastTripLocation$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3184,10 +3146,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<PigeonLastTripLocation?> getLastVehicleTripLocation() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getLastVehicleTripLocation$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getLastVehicleTripLocation$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3208,10 +3168,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<bool> isTripSharingAvailable() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isTripSharingAvailable$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.isTripSharingAvailable$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3236,18 +3194,15 @@ class IOSTripAnalysisApi {
     }
   }
 
-  Future<PigeonCreateTripSharingLinkResponse> createTripSharingLink(
-      int durationInSeconds) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.createTripSharingLink$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+  Future<PigeonCreateTripSharingLinkResponse> createTripSharingLink(int durationInSeconds) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.createTripSharingLink$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[durationInSeconds]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[durationInSeconds]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -3266,19 +3221,15 @@ class IOSTripAnalysisApi {
     }
   }
 
-  Future<PigeonGetTripSharingLinkResponse> getTripSharingLink(
-      {PigeonSynchronizationType synchronizationType =
-          PigeonSynchronizationType.defaultSync}) async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getTripSharingLink$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+  Future<PigeonGetTripSharingLinkResponse> getTripSharingLink({PigeonSynchronizationType synchronizationType = PigeonSynchronizationType.defaultSync}) async {
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.getTripSharingLink$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList = await __pigeon_channel
-        .send(<Object?>[synchronizationType]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(<Object?>[synchronizationType]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -3298,10 +3249,8 @@ class IOSTripAnalysisApi {
   }
 
   Future<PigeonRevokeTripSharingLinkStatus> revokeTripSharingLink() async {
-    final String __pigeon_channelName =
-        'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.revokeTripSharingLink$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel =
-        BasicMessageChannel<Object?>(
+    final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.revokeTripSharingLink$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -3356,33 +3305,22 @@ abstract class FlutterTripAnalysisApi {
 
   void crashDetected(PigeonDKCrashInfo crashInfo);
 
-  void crashFeedbackSent(
-      PigeonDKCrashInfo crashInfo,
-      PigeonDKCrashFeedbackType feedbackType,
-      PigeonDKCrashFeedbackSeverity severity);
+  void crashFeedbackSent(PigeonDKCrashInfo crashInfo, PigeonDKCrashFeedbackType feedbackType, PigeonDKCrashFeedbackSeverity severity);
 
-  static void setUp(
-    FlutterTripAnalysisApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix =
-        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(FlutterTripAnalysisApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingStartedState? arg_state =
-              (args[0] as PigeonTripRecordingStartedState?);
+          final PigeonTripRecordingStartedState? arg_state = (args[0] as PigeonTripRecordingStartedState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingStarted was null, expected non-null PigeonTripRecordingStartedState.');
           try {
@@ -3390,28 +3328,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingConfirmedState? arg_state =
-              (args[0] as PigeonTripRecordingConfirmedState?);
+          final PigeonTripRecordingConfirmedState? arg_state = (args[0] as PigeonTripRecordingConfirmedState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingConfirmed was null, expected non-null PigeonTripRecordingConfirmedState.');
           try {
@@ -3419,28 +3353,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingCanceledState? arg_state =
-              (args[0] as PigeonTripRecordingCanceledState?);
+          final PigeonTripRecordingCanceledState? arg_state = (args[0] as PigeonTripRecordingCanceledState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingCanceled was null, expected non-null PigeonTripRecordingCanceledState.');
           try {
@@ -3448,28 +3378,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripRecordingFinishedState? arg_state =
-              (args[0] as PigeonTripRecordingFinishedState?);
+          final PigeonTripRecordingFinishedState? arg_state = (args[0] as PigeonTripRecordingFinishedState?);
           assert(arg_state != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripRecordingFinished was null, expected non-null PigeonTripRecordingFinishedState.');
           try {
@@ -3477,25 +3403,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripPoint was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonTripPoint? arg_tripPoint = (args[0] as PigeonTripPoint?);
           assert(arg_tripPoint != null,
@@ -3505,18 +3428,15 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripSavedForRepost$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripSavedForRepost$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
@@ -3527,28 +3447,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonTripResponseStatus? arg_response =
-              (args[0] as PigeonTripResponseStatus?);
+          final PigeonTripResponseStatus? arg_response = (args[0] as PigeonTripResponseStatus?);
           assert(arg_response != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.tripFinished was null, expected non-null PigeonTripResponseStatus.');
           try {
@@ -3556,25 +3472,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.potentialTripStart was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonStartMode? arg_startMode = (args[0] as PigeonStartMode?);
           assert(arg_startMode != null,
@@ -3584,18 +3497,15 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconDetected$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconDetected$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
@@ -3606,25 +3516,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.beaconConfirmed was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonBeaconData? arg_beacon = (args[0] as PigeonBeaconData?);
           assert(arg_beacon != null,
@@ -3634,25 +3541,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.significantLocationChangeDetected$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.significantLocationChangeDetected$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.significantLocationChangeDetected was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.significantLocationChangeDetected was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonLocation? arg_location = (args[0] as PigeonLocation?);
           assert(arg_location != null,
@@ -3662,25 +3566,22 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.sdkStateChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final PigeonState? arg_state = (args[0] as PigeonState?);
           assert(arg_state != null,
@@ -3690,28 +3591,24 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonDKCrashInfo? arg_crashInfo =
-              (args[0] as PigeonDKCrashInfo?);
+          final PigeonDKCrashInfo? arg_crashInfo = (args[0] as PigeonDKCrashInfo?);
           assert(arg_crashInfo != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashDetected was null, expected non-null PigeonDKCrashInfo.');
           try {
@@ -3719,47 +3616,39 @@ abstract class FlutterTripAnalysisApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
-              Object?>(
-          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent$messageChannelSuffix',
-          pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent$messageChannelSuffix', pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null.');
+          'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final PigeonDKCrashInfo? arg_crashInfo =
-              (args[0] as PigeonDKCrashInfo?);
+          final PigeonDKCrashInfo? arg_crashInfo = (args[0] as PigeonDKCrashInfo?);
           assert(arg_crashInfo != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null, expected non-null PigeonDKCrashInfo.');
-          final PigeonDKCrashFeedbackType? arg_feedbackType =
-              (args[1] as PigeonDKCrashFeedbackType?);
+          final PigeonDKCrashFeedbackType? arg_feedbackType = (args[1] as PigeonDKCrashFeedbackType?);
           assert(arg_feedbackType != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null, expected non-null PigeonDKCrashFeedbackType.');
-          final PigeonDKCrashFeedbackSeverity? arg_severity =
-              (args[2] as PigeonDKCrashFeedbackSeverity?);
+          final PigeonDKCrashFeedbackSeverity? arg_severity = (args[2] as PigeonDKCrashFeedbackSeverity?);
           assert(arg_severity != null,
               'Argument for dev.flutter.pigeon.pigeon_trip_analysis_package.FlutterTripAnalysisApi.crashFeedbackSent was null, expected non-null PigeonDKCrashFeedbackSeverity.');
           try {
-            api.crashFeedbackSent(
-                arg_crashInfo!, arg_feedbackType!, arg_severity!);
+            api.crashFeedbackSent(arg_crashInfo!, arg_feedbackType!, arg_severity!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/src/trip_analysis_api.g.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/lib/src/trip_analysis_api.g.dart
@@ -2969,7 +2969,7 @@ class IOSTripAnalysisApi {
     }
   }
 
-  Future<void> setBeacons(List<PigeonBeaconData?> beacon) async {
+  Future<void> setBeacons(List<PigeonBeaconData?> beacons) async {
     final String __pigeon_channelName = 'dev.flutter.pigeon.pigeon_trip_analysis_package.IOSTripAnalysisApi.setBeacons$__pigeon_messageChannelSuffix';
     final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
       __pigeon_channelName,
@@ -2977,7 +2977,7 @@ class IOSTripAnalysisApi {
       binaryMessenger: __pigeon_binaryMessenger,
     );
     final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[beacon]) as List<Object?>?;
+        await __pigeon_channel.send(<Object?>[beacons]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/pigeon/messages.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/pigeon/messages.dart
@@ -26,6 +26,7 @@ abstract class IOSTripAnalysisApi {
   bool isMonitoringPotentialTripStart();
   void setMonitorPotentialTripStart(bool activate);
   void setVehicle(PigeonVehicle vehicle);
+  void setBeacons(List<PigeonBeaconData> beacon);
   Map<String, String>? getTripMetadata();
   void updateTripMetadata(String key, String? value);
   void setTripMetadata(Map<String, String>? metadata);

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/pigeon/messages.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/pigeon/messages.dart
@@ -26,7 +26,7 @@ abstract class IOSTripAnalysisApi {
   bool isMonitoringPotentialTripStart();
   void setMonitorPotentialTripStart(bool activate);
   void setVehicle(PigeonVehicle vehicle);
-  void setBeacons(List<PigeonBeaconData> beacon);
+  void setBeacons(List<PigeonBeaconData> beacons);
   Map<String, String>? getTripMetadata();
   void updateTripMetadata(String key, String? value);
   void setTripMetadata(Map<String, String>? metadata);

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/pubspec.lock
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_ios/pubspec.lock
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/lib/flutter_drivekit_trip_analysis_platform_interface.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/lib/flutter_drivekit_trip_analysis_platform_interface.dart
@@ -77,6 +77,9 @@ abstract class DriveKitTripAnalysisPlatform extends PlatformInterface {
   /// Set the user's vehicle.
   Future<void> setVehicle(Vehicle vehicle);
 
+    /// Set the user's beacons.
+  Future<void> setBeacons(List<BeaconData> beacon);
+
   /// Add a listener to receive events concerning trips.
   void addTripListener(TripListener listener);
 

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/lib/flutter_drivekit_trip_analysis_platform_interface.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/lib/flutter_drivekit_trip_analysis_platform_interface.dart
@@ -78,7 +78,7 @@ abstract class DriveKitTripAnalysisPlatform extends PlatformInterface {
   Future<void> setVehicle(Vehicle vehicle);
 
     /// Set the user's beacons.
-  Future<void> setBeacons(List<BeaconData> beacon);
+  Future<void> setBeacons(List<BeaconData> beacons);
 
   /// Add a listener to receive events concerning trips.
   void addTripListener(TripListener listener);

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/lib/src/default_drivekit_trip_analysis.dart
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/lib/src/default_drivekit_trip_analysis.dart
@@ -81,6 +81,11 @@ class DefaultDriveKitTripAnalysis extends DriveKitTripAnalysisPlatform {
   }
 
   @override
+  Future<void> setBeacons(List<BeaconData> beacons) {
+    throw UnimplementedError('setBeacons() has not been implemented.');
+  }
+
+  @override
   Future<void> addTripListener(TripListener listener) {
     throw UnimplementedError('setTripParameters() has not been implemented.');
   }

--- a/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/pubspec.lock
+++ b/packages/drivekit_trip_analysis/flutter_drivekit_trip_analysis_platform_interface/pubspec.lock
@@ -110,10 +110,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator/example/pubspec.lock
+++ b/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator/example/pubspec.lock
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator/pubspec.lock
+++ b/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator/pubspec.lock
@@ -124,10 +124,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -201,10 +201,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator_android/pubspec.lock
+++ b/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator_android/pubspec.lock
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator_ios/pubspec.lock
+++ b/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator_ios/pubspec.lock
@@ -206,10 +206,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator_platform_interface/pubspec.lock
+++ b/packages/drivekit_trip_simulator/flutter_drivekit_trip_simulator_platform_interface/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
# iOS bridge testing 
## Test plan
- Open the app using `flutter run` CLI command
- Press the "Set beacons" button
- Witness logs in the terminal confirming that the 2 beacons were set up correctly

## Results
<img width="997" height="134" alt="image" src="https://github.com/user-attachments/assets/21d59c08-45ee-4374-b8aa-775c19bc2d53" />


# Android bridge testing
## Test plan
- Uninstall/reinstall the application
- Open device explorer in Android Studio
- Browse for `data/data/com.drivequant.drivekit.flutter.example`
- Open the sharedPreferences file (DriveKitPreferences.xml) → witness no field for beacons ("drivekit-beacons")
- Press the "Set beacons" button in the UI of the app 
- Sync the DriveKitPreferences.xml file and witness a new entry containing 2 beacons to monitor
  - 123e4567-e89b-12d3-a456-426614174000 | 1 | 1
  - 123e4567-e89b-12d3-a456-426614174001 | 1 | 2

## Results
**Screenshot from android studio**
<img width="831" height="46" alt="image" src="https://github.com/user-attachments/assets/6b2140cc-006f-49c4-b956-04238d94145b" />

**Value**
```xml
<string name="drivekit-beacons">[{&quot;major&quot;:1,&quot;minor&quot;:1,&quot;proximityUuid&quot;:&quot;123e4567-e89b-12d3-a456-426614174000&quot;},{&quot;major&quot;:1,&quot;minor&quot;:2,&quot;proximityUuid&quot;:&quot;123e4567-e89b-12d3-a456-426614174001&quot;}]</string>
``` 